### PR TITLE
chore: add-issue-templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,22 @@
+name: Bug Report
+description: Report something that isn't working
+title: "[BUG]: <title>"
+labels: ["bug"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: What is happening?
+      description: Describe the bug clearly.
+    validations:
+      required: true
+  - type: input
+    id: environment
+    attributes:
+      label: Environment
+      description: e.g., Chrome, Safari, Codespaces terminal
+  - type: textarea
+    id: fix-suggestion
+    attributes:
+      label: Potential Fix
+      description: If you have an idea of how to fix it, let us know!

--- a/.github/ISSUE_TEMPLATE/docs.yml
+++ b/.github/ISSUE_TEMPLATE/docs.yml
@@ -1,0 +1,10 @@
+name: Documentation Update
+description: Add or update documentation
+title: "[DOCS]: <title>"
+labels: ["documentation"]
+body:
+  - type: textarea
+    id: docs-needed
+    attributes:
+      label: What needs documentation?
+      description: Describe the missing info.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,30 @@
+name: Feature Request
+description: Propose a new feature or UI component
+title: "[FEAT]: <title>"
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: goal
+    attributes:
+      label: What is the goal?
+      description: What are we trying to achieve with this feature?
+    validations:
+      required: true
+  - type: textarea
+    id: technical-tasks
+    attributes:
+      label: Technical Tasks
+      description: List the small steps needed (e.g., "Create API route", "Build React component")
+      placeholder: |
+        - [ ] Task 1
+        - [ ] Task 2
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priority level
+      options:
+        - Low (Nice to have)
+        - Medium (Needed soon)
+        - High (Critical for MVP)
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/refactor.yml
+++ b/.github/ISSUE_TEMPLATE/refactor.yml
@@ -1,0 +1,15 @@
+name: Refactor / Cleanup
+description: Improve code quality without changing functionality
+title: "[REFACTOR]: <title>"
+labels: ["technical-debt"]
+body:
+  - type: textarea
+    id: current-state
+    attributes:
+      label: Current Implementation
+      description: What part of the code is messy or hard to read?
+  - type: textarea
+    id: improvement
+    attributes:
+      label: Proposed Improvement
+      description: How should we rewrite this for better performance or readability?

--- a/.github/ISSUE_TEMPLATE/security.yml
+++ b/.github/ISSUE_TEMPLATE/security.yml
@@ -1,0 +1,20 @@
+name: Security Report
+description: Report a vulnerability or leaked credential
+title: "[SECURITY]: <title>"
+labels: ["critical", "security"]
+body:
+  - type: textarea
+    id: vulnerability
+    attributes:
+      label: Vulnerability Details
+      description: What is the risk? (e.g., "Leaked .env file", "Open API route")
+    validations:
+      required: true
+  - type: dropdown
+    id: severity
+    attributes:
+      label: Severity
+      options:
+        - Critical (Immediate Action)
+        - High (Needs fix today)
+        - Medium (Logic flaw)


### PR DESCRIPTION
## Description
This PR adds formal github issue forms (.yml) to the repository. these templates will force structured input for feature requests, bug reports, refactors, and doc updates ensuring the team provides technical details, priority levels and checklists when creating tasks.

## How to Test
1. go to the Issues tab of the repository
2. click "New Issue"
you should see a list of branded templates (Feature, Bug, etc.) with structured forms instead of a blank text box.

## Folder Affected
- [ ] Frontend
- [ ] Backend
- [x] Docs/Other

## Screenshots (Optional)
## Checklist
- [x] My code follows the project style.
- [x] I have synced with 'main' before opening this PR.